### PR TITLE
fix: add check for core being alive before return

### DIFF
--- a/getter/get_core.c
+++ b/getter/get_core.c
@@ -24,9 +24,9 @@ t_obj	*ft_get_first_opponent_core(void)
 	if (!game.cores)
 		return (NULL);
 
-	while (game.cores[ind] != NULL)
-	{
-		if (game.cores[ind]->s_core.team_id != game.my_team_id)
+	while (game.cores[ind] != NULL) {
+		if ((game.cores[ind]->s_core.team_id != game.my_team_id) &&
+		    (game.cores[ind]->state == STATE_ALIVE))
 			return (game.cores[ind]);
 		ind++;
 	}


### PR DESCRIPTION
Small fix to check if the first found core which is not tagged
with 'my_team_id' is also alive before returning it from 
the function `ft_get_first_opponent_core()`.

fix #109