### PR TITLE
113 null check malloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ parse_json_utils.c \
 parse_json.c \
 formatter.c \
 print_utils.c \
-error.c \
 init_con_utils.c \
 socket.c \
 utils.c \

--- a/actions.c
+++ b/actions.c
@@ -17,7 +17,7 @@ int	ft_travel_to_id(unsigned long id, unsigned long x, unsigned long y)
 	}
 	else
 	{
-		*actions = realloc(*actions, sizeof(t_action_travel) * (*count + 2));
+		*actions = realloc(*actions, sizeof(t_action_travel) * (*count * 2));
 		if (!*actions)
 		{
 			LOG_ERR("Error reallocating actions");
@@ -102,7 +102,7 @@ int	ft_travel_dir_id(unsigned long id, double x, double y)
 	}
 	else
 	{
-		*actions = realloc(*actions, sizeof(t_action_travel) * (*count + 2));
+		*actions = realloc(*actions, sizeof(t_action_travel) * (*count * 2));
 		if (!*actions)
 		{
 			LOG_ERR("Error reallocating actions");
@@ -164,7 +164,7 @@ t_obj	*ft_create_unit(t_unit_type type_id)
 	}
 	else
 	{
-		*actions = realloc(*actions, sizeof(t_action_create) * (*count + 2));
+		*actions = realloc(*actions, sizeof(t_action_create) * (*count * 2));
 		if (!*actions)
 		{
 			LOG_ERR("Error reallocating actions");
@@ -177,9 +177,9 @@ t_obj	*ft_create_unit(t_unit_type type_id)
 	(*count)++;
 
 	t_obj *newUnit = malloc(sizeof(t_obj));
-
 	if (!newUnit)
-		return (NULL);
+		return NULL;
+
 	newUnit->s_unit.type_id = type_id;
 	newUnit->s_unit.team_id = game.my_team_id;
 	newUnit->type = OBJ_UNIT;
@@ -190,7 +190,7 @@ t_obj	*ft_create_unit(t_unit_type type_id)
 	int unitsLen = 0;
 	while (game.units[unitsLen])
 		unitsLen++;
-	game.units = realloc(game.units, sizeof(t_obj *) * (unitsLen + 2));
+	game.units = realloc(game.units, sizeof(t_obj *) * (unitsLen * 2));
 	if (!game.units)
 	{
 		free(newUnit);
@@ -220,7 +220,7 @@ int	ft_attack_id(unsigned long attacker_id, unsigned long target_id)
 	}
 	else
 	{
-		*actions = realloc(*actions, sizeof(t_action_attack) * (*count + 2));
+		*actions = realloc(*actions, sizeof(t_action_attack) * (*count * 2));
 		if (!*actions)
 		{
 			LOG_ERR("Error reallocating actions");

--- a/actions.c
+++ b/actions.c
@@ -1,6 +1,6 @@
 #include "parse_json.h"
 
-void	ft_travel_to_id(unsigned long id, unsigned long x, unsigned long y)
+int	ft_travel_to_id(unsigned long id, unsigned long x, unsigned long y)
 {
 	t_action_travel	**actions = &game.actions.travels;
 	unsigned int	*count = &game.actions.travels_count;
@@ -8,10 +8,22 @@ void	ft_travel_to_id(unsigned long id, unsigned long x, unsigned long y)
 	if (!*actions)
 	{
 		*actions = malloc(sizeof(t_action_travel) * 2);
+		if (!*actions)
+		{
+			LOG_ERR("Error allocating actions");
+			return 1;
+		}
 		*count = 0;
 	}
 	else
+	{
 		*actions = realloc(*actions, sizeof(t_action_travel) * (*count + 2));
+		if (!*actions)
+		{
+			LOG_ERR("Error reallocating actions");
+			return 1;
+		}
+	}
 	(*actions)[*count + 1].id = 0;
 
 	(*actions)[*count].id = id;
@@ -19,32 +31,54 @@ void	ft_travel_to_id(unsigned long id, unsigned long x, unsigned long y)
 	(*actions)[*count].x = x;
 	(*actions)[*count].y = y;
 	(*count)++;
+
+	return 0;
 }
 
-void	ft_travel_to(t_obj *unit, unsigned long x, unsigned long y)
+int	ft_travel_to(t_obj *unit, unsigned long x, unsigned long y)
 {
 	if (unit == NULL)
-		return;
+	{
+		LOG_ERR("Error: unit or target == NULL");
+		return 1;
+	}
 	if (unit->type != OBJ_UNIT)
-		return (ft_print_error("OBJ is not type of UNIT", __func__));
-	ft_travel_to_id(unit->id, x, y);
+	{
+		LOG_ERR("OBJ is not type of UNIT");
+		return 1;
+	}
+	if (ft_travel_to_id(unit->id, x, y))
+		return 1;
+	return 0;
 }
 
-void	ft_travel_to_id_obj(unsigned long id, t_obj *target)
+int	ft_travel_to_id_obj(unsigned long id, t_obj *target)
 {
-	ft_travel_to_id(id, target->x, target->y);
+	if (ft_travel_to_id(id, target->x, target->y))
+		return 1;
+
+	return 0;
 }
 
-void	ft_travel_to_obj(t_obj *unit, t_obj *target)
+int	ft_travel_to_obj(t_obj *unit, t_obj *target)
 {
 	if (unit == NULL || target == NULL)
-		return;
+	{
+		LOG_ERR("Error: unit or target == NULL");
+		return 1;
+	}
 	if (unit->type != OBJ_UNIT)
-		return (ft_print_error("OBJ is not type of UNIT", __func__));
-	ft_travel_to(unit, target->x, target->y);
+	{
+		LOG_ERR("OBJ is not type of UNIT");
+		return 1;
+	}
+	if (ft_travel_to(unit, target->x, target->y))
+		return 1;
+
+	return 0;
 }
 
-void	ft_travel_dir_id(unsigned long id, double x, double y)
+int	ft_travel_dir_id(unsigned long id, double x, double y)
 {
 	t_action_travel	**actions = &game.actions.travels;
 	unsigned int	*count = &game.actions.travels_count;
@@ -59,10 +93,22 @@ void	ft_travel_dir_id(unsigned long id, double x, double y)
 	if (!*actions)
 	{
 		*actions = malloc(sizeof(t_action_travel) * 2);
+		if (!*actions)
+		{
+			LOG_ERR("Error allocating actions");
+			return 1;
+		}
 		*count = 0;
 	}
 	else
+	{
 		*actions = realloc(*actions, sizeof(t_action_travel) * (*count + 2));
+		if (!*actions)
+		{
+			LOG_ERR("Error reallocating actions");
+			return 1;
+		}
+	}
 	(*actions)[*count + 1].id = 0;
 
 	(*actions)[*count].id = id;
@@ -70,20 +116,32 @@ void	ft_travel_dir_id(unsigned long id, double x, double y)
 	(*actions)[*count].x = x_long;
 	(*actions)[*count].y = y_long;
 	(*count)++;
+
+	return 0;
 }
 
-void	ft_travel_dir(t_obj *unit, double x, double y)
+int	ft_travel_dir(t_obj *unit, double x, double y)
 {
 	if (unit == NULL)
-		return;
+		return 1;
 	if (unit->type != OBJ_UNIT)
-		return (ft_print_error("OBJ is not type of UNIT", __func__));
-	ft_travel_dir_id(unit->id, x, y);
+	{
+		LOG_ERR("OBJ is not type of UNIT");
+		return 1;
+	}
+	if (ft_travel_dir_id(unit->id, x, y))
+		return 1;
+
+	return 0;
 }
 
 t_obj	*ft_create_unit(t_unit_type type_id)
 {
 	int unit_count = 0;
+	t_action_create	**actions;
+	unsigned int	*count;
+
+
 	while ((int)game.config.units[unit_count].type_id != 0)
 		unit_count++;
 	if ((int)type_id < 1 || (int)type_id > unit_count)
@@ -91,22 +149,37 @@ t_obj	*ft_create_unit(t_unit_type type_id)
 	if (game.config.units[type_id - 1].cost > ft_get_my_team()->balance)
 		return NULL;
 
-	t_action_create	**actions = &game.actions.creates;
-	unsigned int	*count = &game.actions.creates_count;
+	actions = &game.actions.creates;
+	count = &game.actions.creates_count;
 
 	if (!*actions)
 	{
 		*actions = malloc(sizeof(t_action_create) * 2);
+		if (!*actions)
+		{
+			LOG_ERR("Error allocating actions");
+			return NULL;
+		}
 		*count = 0;
 	}
 	else
+	{
 		*actions = realloc(*actions, sizeof(t_action_create) * (*count + 2));
+		if (!*actions)
+		{
+			LOG_ERR("Error reallocating actions");
+			return NULL;
+		}
+	}
 	(*actions)[*count + 1].type_id = 0;
 
 	(*actions)[*count].type_id = type_id;
 	(*count)++;
 
 	t_obj *newUnit = malloc(sizeof(t_obj));
+
+	if (!newUnit)
+		return (NULL);
 	newUnit->s_unit.type_id = type_id;
 	newUnit->s_unit.team_id = game.my_team_id;
 	newUnit->type = OBJ_UNIT;
@@ -118,13 +191,19 @@ t_obj	*ft_create_unit(t_unit_type type_id)
 	while (game.units[unitsLen])
 		unitsLen++;
 	game.units = realloc(game.units, sizeof(t_obj *) * (unitsLen + 2));
+	if (!game.units)
+	{
+		free(newUnit);
+		LOG_ERR("Error reallocating game.units");
+		return NULL;
+	}
 	game.units[unitsLen] = newUnit;
 	game.units[unitsLen + 1] = NULL;
 
 	return newUnit;
 }
 
-void	ft_attack_id(unsigned long attacker_id, unsigned long target_id)
+int	ft_attack_id(unsigned long attacker_id, unsigned long target_id)
 {
 	t_action_attack	**actions = &game.actions.attacks;
 	unsigned int	*count = &game.actions.attacks_count;
@@ -132,29 +211,54 @@ void	ft_attack_id(unsigned long attacker_id, unsigned long target_id)
 	if (!*actions)
 	{
 		*actions = malloc(sizeof(t_action_attack) * 2);
+		if (!*actions)
+		{
+			LOG_ERR("Error allocating actions");
+			return 1;
+		}
 		*count = 0;
 	}
 	else
+	{
 		*actions = realloc(*actions, sizeof(t_action_attack) * (*count + 2));
+		if (!*actions)
+		{
+			LOG_ERR("Error reallocating actions");
+			return 1;
+		}
+
+	}
 	(*actions)[*count + 1].attacker_id = 0;
 
 	(*actions)[*count].attacker_id = attacker_id;
 	(*actions)[*count].target_id = target_id;
 	(*count)++;
+
+	return 0;
 }
 
-void	ft_attack(t_obj *attacker_unit, t_obj *target_obj)
+int	ft_attack(t_obj *attacker_unit, t_obj *target_obj)
 {
 	if (attacker_unit == NULL || target_obj == NULL)
-		return;
+		return 1;
 	if (attacker_unit->type != OBJ_UNIT)
-		return ft_print_error("Attacker OBJ is not type of UNIT", __func__);
+	{
+		LOG_ERR("Attacker OBJ is not type of UNIT");
+		return 1;
 
-	ft_attack_id(attacker_unit->id, target_obj->id);
+	}
+	if (ft_attack_id(attacker_unit->id, target_obj->id))
+		return 1;
+
+	return 0;
 }
 
-void	ft_travel_attack(t_obj *attacker_unit, t_obj *attack_obj)
+int	ft_travel_attack(t_obj *attacker_unit, t_obj *attack_obj)
 {
-	ft_travel_to_obj(attacker_unit, attack_obj);
-	ft_attack(attacker_unit, attack_obj);
+	if (ft_travel_to_obj(attacker_unit, attack_obj))
+		return 1;
+	if (ft_attack(attacker_unit, attack_obj))
+		return 1;
+
+	return 0;
 }

--- a/getter/get_unit.c
+++ b/getter/get_unit.c
@@ -17,6 +17,9 @@ t_obj	**ft_get_my_units(void)
 	}
 
 	t_obj	**units = malloc((count + 1) * sizeof(t_obj *));
+
+	if (!units)
+		return (NULL);
 	ind = 0;
 	count = 0;
 	while (game.units[ind] != NULL)
@@ -48,6 +51,9 @@ t_obj	**ft_get_opponent_units(void)
 	}
 
 	t_obj	**units = malloc((count + 1) * sizeof(t_obj *));
+
+	if (!units)
+		return (NULL);
 	ind = 0;
 	count = 0;
 	while (game.units[ind] != NULL)

--- a/getter/get_unit.c
+++ b/getter/get_unit.c
@@ -17,9 +17,9 @@ t_obj	**ft_get_my_units(void)
 	}
 
 	t_obj	**units = malloc((count + 1) * sizeof(t_obj *));
-
 	if (!units)
 		return (NULL);
+
 	ind = 0;
 	count = 0;
 	while (game.units[ind] != NULL)
@@ -51,9 +51,9 @@ t_obj	**ft_get_opponent_units(void)
 	}
 
 	t_obj	**units = malloc((count + 1) * sizeof(t_obj *));
-
 	if (!units)
 		return (NULL);
+
 	ind = 0;
 	count = 0;
 	while (game.units[ind] != NULL)

--- a/inc/con_lib.h
+++ b/inc/con_lib.h
@@ -301,7 +301,7 @@ double	ft_distance(t_obj *obj1, t_obj *obj2);
  * @param x To which x coordinate the unit should travel.
  * @param y To which y coordinate the unit should travel.
  */
-void ft_travel_to_id(unsigned long id, unsigned long x, unsigned long y);
+int ft_travel_to_id(unsigned long id, unsigned long x, unsigned long y);
 /**
  * @brief Lets a unit travel to a specific coordinate. Same as ft_travel_to_id, besides that this function takes a pointer to a unit instead of an id.
  *
@@ -309,7 +309,7 @@ void ft_travel_to_id(unsigned long id, unsigned long x, unsigned long y);
  * @param x To which x coordinate the unit should travel.
  * @param y To which y coordinate the unit should travel.
  */
-void ft_travel_to(t_obj *unit, unsigned long x, unsigned long y);
+int ft_travel_to(t_obj *unit, unsigned long x, unsigned long y);
 /**
  * @brief Lets a unit start to travel into a specific direction. Same as ft_travel_dir, besides that this function takes an id instead of a pointer to a unit. When x and y are both 0, the unit will stop traveling.
  *
@@ -317,7 +317,7 @@ void ft_travel_to(t_obj *unit, unsigned long x, unsigned long y);
  * @param x x vector of the direction the unit should travel.
  * @param y y vector of the direction the unit should travel.
  */
-void ft_travel_dir_id(unsigned long id, double x, double y);
+int ft_travel_dir_id(unsigned long id, double x, double y);
 /**
  * @brief Lets a unit start to travel into a specific direction. Same as ft_travel_dir_id, besides that this function takes a pointer to a unit instead of an id. When x and y are both 0, the unit will stop traveling.
  *
@@ -325,21 +325,21 @@ void ft_travel_dir_id(unsigned long id, double x, double y);
  * @param x x vector of the direction the unit should travel.
  * @param y y vector of the direction the unit should travel.
  */
-void ft_travel_dir(t_obj *unit, double x, double y);
+int ft_travel_dir(t_obj *unit, double x, double y);
 /**
  * @brief Lets a unit travel to another obj. Same as ft_travel_to_id, besides that this function takes an id instead of a pointer to a unit.
  *
  * @param id Which unit should travel.
  * @param target To which obj the unit should travel.
  */
-void ft_travel_to_id_obj(unsigned long id, t_obj *target);
+int ft_travel_to_id_obj(unsigned long id, t_obj *target);
 /**
  * @brief Lets a unit travel to another obj. Same as ft_travel_to_id_obj, besides that this function takes a pointer to a unit instead of an id.
  *
  * @param unit Pointer to the unit that should travel.
  * @param target Pointer to the obj that the unit should travel to.
  */
-void ft_travel_to_obj(t_obj *unit, t_obj *target);
+int ft_travel_to_obj(t_obj *unit, t_obj *target);
 /**
  * @brief Creates a unit of a specific type. Same as ft_create, besides that this function takes an id instead of a pointer to a unit.
  *
@@ -352,21 +352,21 @@ t_obj	*ft_create_unit(t_unit_type type_id);
  * @param attacker_id Which unit should be used to attack.
  * @param target_id Which unit should be attacked.
  */
-void ft_attack_id(unsigned long attacker_id, unsigned long target_id);
+int ft_attack_id(unsigned long attacker_id, unsigned long target_id);
 /**
  * @brief Lets a unit attack another unit. Same as ft_attack_id, besides that this function takes a pointer to a unit instead of an id.
  *
  * @param attacker_unit Pointer to the unit that should be used to attack.
  * @param target_obj Pointer to the obj that should be attacked.
  */
-void ft_attack(t_obj *attacker, t_obj *target);
+int ft_attack(t_obj *attacker, t_obj *target);
 /**
  * @brief Travel and attack a target. The unit will travel to the target and attack it. Same as calling ft_travel_to_obj and ft_attack.
  *
  * @param attacker_unit Pointer to the unit that should be used to attack.
  * @param attack_obj Pointer to the unit that should be attacked.
  */
-void ft_travel_attack(t_obj *attacker_unit, t_obj *attack_obj);
+int ft_travel_attack(t_obj *attacker_unit, t_obj *attack_obj);
 
 // -------------- print_utils.c --------------
 /**

--- a/inc/utils.h
+++ b/inc/utils.h
@@ -9,6 +9,8 @@
 
 # include "con_lib.h"
 
+#define LOG_ERR(fmt, ...) fprintf(stderr, "%s:%d: Error:" fmt "\n", __FUNCTION__, __LINE__, ##__VA_ARGS__)
+
 //utils.c
 void	ft_parse_json_config(char *json);
 void	ft_parse_json_state(char *json);

--- a/json/parse_json_configs.c
+++ b/json/parse_json_configs.c
@@ -11,7 +11,9 @@ t_team_config	*ft_parse_team_config(int token_ind, int token_len, jsmntok_t *tok
 	last_json_index = tokens[token_ind].end;
 
 	teams = malloc(sizeof(t_team_config));
-	teams[0].id = 0;
+	if (!teams)
+		ft_perror_exit("Could not allocate memory for team config");
+	teams->id = 0;
 
 	int index = 0;
 	while (token_ind != -1)
@@ -20,7 +22,9 @@ t_team_config	*ft_parse_team_config(int token_ind, int token_len, jsmntok_t *tok
 		if (next_token_ind == -1 || tokens[next_token_ind].end > last_json_index)
 			break;
 
-		teams = realloc(teams, sizeof(t_team_config) * (index + 2));
+		teams = realloc(teams, sizeof(t_team_config) * (index * 2));
+		if (!teams)
+			ft_perror_exit("Failed to realloc team config array");
 		teams[index + 1].id = 0;
 
 		teams[index].id = ft_find_parse_ulong("id", &token_ind, token_len, tokens, json);
@@ -43,7 +47,9 @@ t_unit_config	*ft_parse_unit_config(int token_ind, int token_len, jsmntok_t *tok
 	last_json_index = tokens[token_ind].end;
 
 	units = malloc(sizeof(t_unit_config));
-	units[0].type_id = 0;
+	if (!units)
+		ft_perror_exit("Could not allocate memory for unit config");
+	units->type_id = 0;
 
 	int index = 0;
 	while (token_ind != -1)
@@ -52,7 +58,9 @@ t_unit_config	*ft_parse_unit_config(int token_ind, int token_len, jsmntok_t *tok
 		if (next_token_ind == -1 || tokens[next_token_ind].end > last_json_index)
 			break;
 
-		units = realloc(units, sizeof(t_unit_config) * (index + 2));
+		units = realloc(units, sizeof(t_unit_config) * (index * 2));
+		if (!units)
+			ft_perror_exit("Failed to realloc team config array");
 		units[index + 1].type_id = 0;
 
 		units[index].name = ft_find_parse_str("name", &token_ind, token_len, tokens, json);
@@ -83,7 +91,9 @@ t_resource_config	*ft_parse_resource_config(int token_ind, int token_len, jsmnto
 	last_json_index = tokens[token_ind].end;
 
 	resource_configs = malloc(sizeof(t_resource_config));
-	resource_configs[0].type_id = 0;
+	if (!resource_configs)
+		ft_perror_exit("Could not allocate memory for resource_configs");
+	resource_configs->type_id = 0;
 
 	int index = 0;
 	while (token_ind != -1)
@@ -92,7 +102,9 @@ t_resource_config	*ft_parse_resource_config(int token_ind, int token_len, jsmnto
 		if (next_token_ind == -1 || tokens[next_token_ind].end > last_json_index)
 			break;
 
-		resource_configs = realloc(resource_configs, sizeof(t_resource_config) * (index + 2));
+		resource_configs = realloc(resource_configs, sizeof(t_resource_config) * (index * 2));
+		if (!resource_configs)
+			ft_perror_exit("Failed to realloc resource config array");
 		resource_configs[index + 1].type_id = 0;
 
 		resource_configs[index].type_id = ft_find_parse_ulong("type_id", &token_ind, token_len, tokens, json);

--- a/json/parse_json_objects.c
+++ b/json/parse_json_objects.c
@@ -1,6 +1,6 @@
 #include "parse_json.h"
 
-static void apply_obj_to_arr(t_obj obj, t_obj ***arr)
+static int apply_obj_to_arr(t_obj obj, t_obj ***arr)
 {
 	bool objInserted = false;
 	size_t arrLen;
@@ -34,7 +34,7 @@ static void apply_obj_to_arr(t_obj obj, t_obj ***arr)
 		index++;
 	}
 	if (objInserted)
-		return ;
+		return 0;
 
 	// 2. LOOP: Placeholder matching
 	index = 0;
@@ -68,7 +68,7 @@ static void apply_obj_to_arr(t_obj obj, t_obj ***arr)
 		index++;
 	}
 	if (objInserted)
-		return ;
+		return 0;
 
 	if ((*arr) == game.units && obj.s_unit.team_id == game.my_team_id)
 	{
@@ -79,18 +79,18 @@ static void apply_obj_to_arr(t_obj obj, t_obj ***arr)
 	arrLen = 0;
 	while ((*arr)[arrLen] != NULL)
 		arrLen++;
-	(*arr) = realloc((*arr), sizeof(t_obj *) * (arrLen + 2));
+	(*arr) = realloc((*arr), sizeof(t_obj *) * (arrLen * 2));
 	if (!*arr)
 	{
 		LOG_ERR("failed to reallocate array");
-		return;
+		return 1;
 	}
 	(*arr)[arrLen + 1] = NULL;
 	(*arr)[arrLen] = malloc(sizeof(t_obj));
 	if (!(*arr)[arrLen])
 	{
 		LOG_ERR("failed to allocate new element");
-		return;
+		return 1;
 	}
 	t_obj * existingObj = (*arr)[arrLen];
 	existingObj->type = obj.type;
@@ -107,6 +107,8 @@ static void apply_obj_to_arr(t_obj obj, t_obj ***arr)
 	}
 	if ((*arr) == game.cores)
 		existingObj->s_core.team_id = obj.s_core.team_id;
+
+	return 0;
 }
 
 void ft_parse_cores(int token_ind, int token_len, jsmntok_t *tokens, char *json)
@@ -121,6 +123,8 @@ void ft_parse_cores(int token_ind, int token_len, jsmntok_t *tokens, char *json)
 	if (game.cores == NULL)
 	{
 		game.cores = malloc(sizeof(t_obj *) * 1);
+		if (!game.cores)
+			ft_perror_exit("Could not allocate memory for cores");
 		game.cores[0] = NULL;
 	}
 
@@ -143,7 +147,8 @@ void ft_parse_cores(int token_ind, int token_len, jsmntok_t *tokens, char *json)
 		readCore.y = ft_find_parse_ulong("y", &token_ind, token_len, tokens, json);
 		readCore.hp = ft_find_parse_ulong("hp", &token_ind, token_len, tokens, json);
 
-		apply_obj_to_arr(readCore, &game.cores);
+		if (apply_obj_to_arr(readCore, &game.cores))
+			ft_perror_exit("Could not apply obj to array");
 
 		index++;
 	}
@@ -161,6 +166,8 @@ void	ft_parse_resources(int token_ind, int token_len, jsmntok_t *tokens, char *j
 	if (game.resources == NULL)
 	{
 		game.resources = malloc(sizeof(t_obj *) * 1);
+		if (!game.resources)
+			ft_perror_exit("Could not allocate memory for resources");
 		game.resources[0] = NULL;
 	}
 
@@ -182,7 +189,8 @@ void	ft_parse_resources(int token_ind, int token_len, jsmntok_t *tokens, char *j
 		readResource.y = ft_find_parse_ulong("y", &token_ind, token_len, tokens, json);
 		readResource.hp = ft_find_parse_ulong("hp", &token_ind, token_len, tokens, json);
 
-		apply_obj_to_arr(readResource, &game.resources);
+		if (apply_obj_to_arr(readResource, &game.resources))
+			ft_perror_exit("Could not apply obj to array");
 
 		index++;
 	}
@@ -200,6 +208,8 @@ void	ft_parse_units(int token_ind, int token_len, jsmntok_t *tokens, char *json)
 	if (game.units == NULL)
 	{
 		game.units = malloc(sizeof(t_obj *) * 1);
+		if (!game.units)
+			ft_perror_exit("Could not allocate memory for units");
 		game.units[0] = NULL;
 	}
 
@@ -219,7 +229,8 @@ void	ft_parse_units(int token_ind, int token_len, jsmntok_t *tokens, char *json)
 		readUnit.x = ft_find_parse_ulong("x", &token_ind, token_len, tokens, json);
 		readUnit.y = ft_find_parse_ulong("y", &token_ind, token_len, tokens, json);
 
-		apply_obj_to_arr(readUnit, &game.units);
+		if (apply_obj_to_arr(readUnit, &game.units))
+			ft_perror_exit("Could not apply obj to array");
 
 		index++;
 	}
@@ -248,11 +259,15 @@ void ft_parse_teams(int token_ind, int token_len, jsmntok_t *tokens, char *json)
 	if (game.teams == NULL)
 	{
 		game.teams = malloc(sizeof(t_team *) * (teamCount + 1));
+		if (!game.teams)
+			ft_perror_exit("Could not allocate memory for teams");
 		game.teams[teamCount] = NULL;
 
 		for (size_t i = 0; i < teamCount; i++)
 		{
 			game.teams[i] = malloc(sizeof(t_team));
+			if (!game.teams[i])
+				ft_perror_exit("could not allocate memory for a team");
 			game.teams[i]->id = 0;
 			game.teams[i]->balance = 0;
 		}

--- a/json/parse_json_objects.c
+++ b/json/parse_json_objects.c
@@ -3,11 +3,13 @@
 static void apply_obj_to_arr(t_obj obj, t_obj ***arr)
 {
 	bool objInserted = false;
+	size_t arrLen;
+	size_t index;
 
 	obj.state = STATE_ALIVE;
 
 	// 1. LOOP: Id Matching
-	size_t index = 0;
+	index = 0;
 	while ((*arr)[index] != NULL)
 	{
 		if ((*arr)[index]->id == obj.id)
@@ -74,12 +76,22 @@ static void apply_obj_to_arr(t_obj obj, t_obj ***arr)
 	}
 
 	// 3. Add to the back
-	size_t arrLen = 0;
+	arrLen = 0;
 	while ((*arr)[arrLen] != NULL)
 		arrLen++;
 	(*arr) = realloc((*arr), sizeof(t_obj *) * (arrLen + 2));
+	if (!*arr)
+	{
+		LOG_ERR("failed to reallocate array");
+		return;
+	}
 	(*arr)[arrLen + 1] = NULL;
 	(*arr)[arrLen] = malloc(sizeof(t_obj));
+	if (!(*arr)[arrLen])
+	{
+		LOG_ERR("failed to allocate new element");
+		return;
+	}
 	t_obj * existingObj = (*arr)[arrLen];
 	existingObj->type = obj.type;
 	existingObj->state = STATE_ALIVE;

--- a/utils/error.c
+++ b/utils/error.c
@@ -1,6 +1,0 @@
-#include "utils.h"
-
-void ft_print_error(char *str, const char *func_name)
-{
-	fprintf(stderr, "Error: %s: %s\n", func_name, str);
-}

--- a/utils/init_con_utils.c
+++ b/utils/init_con_utils.c
@@ -11,6 +11,11 @@ static char *ft_create_str(char *team_name, char *id)
 		len += strlen(id);
 
 	msg = malloc(sizeof(char) * (len + 26));
+	if (!msg)
+	{
+		LOG_ERR("Error allocating memory for message");
+		return NULL;
+	}
 	if (team_name != NULL && id != NULL)
 		sprintf(msg, "{\"id\": %s, \"name\": \"%s\"}\n", id, team_name);
 	else if (id != NULL)
@@ -19,7 +24,7 @@ static char *ft_create_str(char *team_name, char *id)
 		sprintf(msg, "{\"id\": 1, \"name\": \"%s\"}\n", team_name);
 	else
 		sprintf(msg, "{\"id\": 1}\n");
-	return (msg);
+	return msg;
 }
 
 char	*ft_create_login_msg(char *team_name, int *argc, char **argv)

--- a/utils/socket.c
+++ b/utils/socket.c
@@ -71,12 +71,12 @@ bool ft_wait_for_data(int fd) {
     retval = select(fd + 1, &readfds, NULL, NULL, &tv);
 
     if (retval == -1) {
-        ft_print_error(strerror(errno), __func__);
+        LOG_ERR("%s", strerror(errno));
         return false;
     } else if (retval) {
         return true;
     } else {
-		ft_print_error("Did not recieve any data from socket fd", __func__);
+        LOG_ERR("Did not recieve any data from socket fd");
         return false;
     }
 }
@@ -120,7 +120,7 @@ struct sockaddr_in	ft_init_addr(const char *hostname, const int port)
     hints.ai_socktype = SOCK_STREAM;
 
     if ((status = getaddrinfo(hostname, NULL, &hints, &res)) != 0) {
-        fprintf(stderr, "getaddrinfo error: %s\n", gai_strerror(status));
+	LOG_ERR("getaddrinfo error: %s", gai_strerror(status));
         exit(EXIT_FAILURE);
     }
 
@@ -138,7 +138,7 @@ struct sockaddr_in	ft_init_addr(const char *hostname, const int port)
 
     if (p == NULL) {
         // We didn't find any address
-        fprintf(stderr, "Failed to resolve hostname\n");
+	LOG_ERR("Failed to resolve hostname");
         exit(EXIT_FAILURE);
     }
 

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -10,7 +10,7 @@ char	**ft_create_array(const int count, ...)
 	va_start(args, count);
 	array = malloc(sizeof(char *) * (count + 1));
 	if (!array)
-		return (0);
+		return NULL;
 	i = 0;
 	while (i < count)
 	{
@@ -19,7 +19,7 @@ char	**ft_create_array(const int count, ...)
 	}
 	array[i] = 0;
 	va_end(args);
-	return (array);
+	return array;
 }
 
 char	*ft_substr(char const *s, unsigned int start, size_t len)
@@ -28,7 +28,7 @@ char	*ft_substr(char const *s, unsigned int start, size_t len)
 	char	*ptr;
 
 	if (!s)
-		return (0);
+		return NULL;
 	if (start >= strlen(s))
 		len_s = 0;
 	else
@@ -37,12 +37,12 @@ char	*ft_substr(char const *s, unsigned int start, size_t len)
 		len = len_s;
 	ptr = malloc((len + 1) * sizeof(char));
 	if (!ptr)
-		return (0);
+		return NULL;
 	if (len > 0)
 		ft_strlcpy(ptr, &s[start], len + 1);
 	else
 		ptr[0] = 0;
-	return (ptr);
+	return ptr;
 }
 
 int	ft_strncmp(const char *s1, const char *s2, size_t n)
@@ -55,10 +55,10 @@ int	ft_strncmp(const char *s1, const char *s2, size_t n)
 	sc1 = (unsigned char *) s1;
 	sc2 = (unsigned char *) s2;
 	if (n == 0)
-		return (0);
+		return 0;
 	while (s1[i] && s2[i] && s1[i] == s2[i] && i < n - 1)
 		i++;
-	return (sc1[i] - sc2[i]);
+	return sc1[i] - sc2[i];
 }
 
 size_t	ft_strlcpy(char *dst, const char *src, size_t dstsize)
@@ -68,7 +68,7 @@ size_t	ft_strlcpy(char *dst, const char *src, size_t dstsize)
 
 	len_src = strlen(src);
 	if (dstsize == 0)
-		return (len_src);
+		return len_src;
 	i = 0;
 	while (i < dstsize - 1 && i < len_src)
 	{
@@ -76,7 +76,7 @@ size_t	ft_strlcpy(char *dst, const char *src, size_t dstsize)
 		i++;
 	}
 	dst[i] = 0;
-	return (len_src);
+	return len_src;
 }
 
 void	ft_free_game()


### PR DESCRIPTION
## rework of function prototypes

Changed multiple functions to use an int as return value to check if the function failed.
Also protected every malloc call and used the `LOG_ERR(fmt, ...)` macro for error logging.

Use `* 2` for increasing the array size for `realloc()` to reduce malloc calls in general like
`std::vector` is also using internally when increasing the size.

close #113 